### PR TITLE
added support for SASL auth commands

### DIFF
--- a/mc_constants.go
+++ b/mc_constants.go
@@ -54,6 +54,10 @@ const (
 	RDECR      = CommandCode(0x3b)
 	RDECRQ     = CommandCode(0x3c)
 
+	SASL_LIST_MECHS = CommandCode(0x20)
+	SASL_AUTH       = CommandCode(0x21)
+	SASL_STEP       = CommandCode(0x22)
+
 	TAP_CONNECT          = CommandCode(0x40)
 	TAP_MUTATION         = CommandCode(0x41)
 	TAP_DELETE           = CommandCode(0x42)


### PR DESCRIPTION
this is required to allow go-couchbase to write to buckets other than default

all the changes from "dustin" to "mschoch" are unfortunate, but i didn't see a good way around that to easily test my changes and eventually send a pull request.  perhaps you can suggest a better workflow.

also, this is my first go.
