### PR TITLE
Return the most up-to-date CAS on success.

### DIFF
--- a/client/mc.go
+++ b/client/mc.go
@@ -378,6 +378,7 @@ func (client *Client) CASNext(vb uint16, k string, exp int, state *CASState) boo
 		// get the new value (below). Otherwise, we're done (either success or failure) so return:
 		if !(state.resp != nil && (state.resp.Status == gomemcached.KEY_EEXISTS ||
 			state.resp.Status == gomemcached.NOT_STORED)) {
+			state.Cas = state.resp.Cas
 			return false // either success or fatal error
 		}
 	}


### PR DESCRIPTION
Normally CAS isn't checked in the success cases, except when
waiting on data to be persisted. Peviously the library failed
to update the CAS value on success causing WriteUpdate calls with
the Index/Persist flags set to always fail with ErrOverwritten.

These were false errors, as the library was always using the
pre-modification CAS value as input into the observe function
instead of the post-modification CAS value.
